### PR TITLE
Fix BoardSetup indexer bug

### DIFF
--- a/src/pgn.Data/BoardSetup.cs
+++ b/src/pgn.Data/BoardSetup.cs
@@ -51,8 +51,8 @@ namespace ilf.pgn.Data
         /// </returns>
         public Piece this[Square square]
         {
-            get { return this[(int)square.File, square.Rank]; }
-            set { this[(int)square.File, square.Rank] = value; }
+            get { return this[square.File, square.Rank]; }
+            set { this[square.File, square.Rank] = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
When you try BoardSetup[Square] the indexer have a bug because it
traduce the Square into file and rank (int,int) but not dismiss the file
and rank index by 1.
